### PR TITLE
Admin-Linst+ERROR500-on-Delete+Message

### DIFF
--- a/Back-End/src/chat/chat.service.ts
+++ b/Back-End/src/chat/chat.service.ts
@@ -98,7 +98,6 @@ export class ChatService {
         }
     };
 
-
     chatBlock:any = (blockFrom: number, blockTo: number,) => {
         const userTo = this.getUser(blockTo);
         const userFrom = this.getUser(blockFrom);
@@ -141,11 +140,12 @@ export class ChatService {
 
     chatJoinedChannel: any = (channelId: number , socketId: string) => {
         this.server.to(socketId).emit('joinedChannelR2', channelId);
-        this.server.emit('joinedChannelR3');
+        this.server.emit('changeParticipants');
 	};
 
     chatLeavedChannel: any = (channelId: number , socketId: string) => {
         this.server.to(socketId).emit('leavedChannel', channelId);
+        this.server.emit('changeParticipants');
     };
 
     invitedToPriv: any = (channelId: number, invitedId: number, socketId: string) => {
@@ -155,7 +155,7 @@ export class ChatService {
 
     acceptedToPriv: any = (socketId: string) => {
         this.server.to(socketId).emit('newPriv');
-        this.server.emit('newPriv2');
+        this.server.emit('changeParticipants');
     };
 }
 

--- a/Back-End/src/gateway/global.gateway.ts
+++ b/Back-End/src/gateway/global.gateway.ts
@@ -219,9 +219,8 @@ export class GlobalGateway implements OnGatewayInit, OnGatewayConnection, OnGate
 	}
 
   @SubscribeMessage('removeConv')
-	async removeConv(@MessageBody() data: any ): Promise<void> {
-		const newList = await this.chatroomService.findAll();
-		this.server.emit('deleteChannel', newList);
+	async removeConv(@MessageBody() data: {channelId: number }): Promise<void> {
+		this.server.emit('deleteChannel', data);
 	}
 
   @SubscribeMessage('showUsersList')

--- a/Front-End/src/components/chat/Chat.tsx
+++ b/Front-End/src/components/chat/Chat.tsx
@@ -313,13 +313,12 @@ function Chat(props: any) {
 		setActiveTab(newValue);
 	  };
 
-  // TESTS
 	useEffect(() => { 
   if (currentChat)
     {
       setShowUserList(false);
       setShowUsersOnChannel(true);
-    };
+    }
   }, [currentChat]);
 
 	return (

--- a/Front-End/src/components/chat/channels/CurrentChannel.tsx
+++ b/Front-End/src/components/chat/channels/CurrentChannel.tsx
@@ -156,6 +156,13 @@ export default function CurrentChannel(props: any) {
 		setIsJoined(false);
 	};
 
+	useEffect(() => {
+		addListener("deleteChannel", (channelId: any) => {
+			if (currentChatroom.id === channelId.channelId)
+			{	handleDeleteChannel()};
+		});
+	});
+
 	return (
 		<>
 			{isJoined && !isBanned && (

--- a/Front-End/src/components/chat/channels/NavbarChannel.tsx
+++ b/Front-End/src/components/chat/channels/NavbarChannel.tsx
@@ -106,7 +106,7 @@ export function NavbarChannel(props: any) {
             });
             const data = await response.json();
             props.onDeleteChannel();
-			sendMessage("removeConv", data)
+			sendMessage("removeConv", {channelId: channelId})
 			sendMessage("showUsersList", data)
             return data;
 

--- a/Front-End/src/components/chat/channels/UpdateChannelsInList.tsx
+++ b/Front-End/src/components/chat/channels/UpdateChannelsInList.tsx
@@ -28,7 +28,9 @@ export default function UpdateChannelsInList(props: any) {
 	});
 
 	useEffect(() => {
-		addListener("deleteChannel", data => {setAConversation(data)});
+		addListener("deleteChannel", () => {
+			getAllConv(user);
+		});
 	});
 
 	useEffect(() => {

--- a/Front-End/src/components/chat/channels/UsersOnChannel.tsx
+++ b/Front-End/src/components/chat/channels/UsersOnChannel.tsx
@@ -67,7 +67,7 @@ export default function InteractiveListe(props: any) {
 	}, [authCtx.token]);
 
 	useEffect(() => {
-		addListener("newPriv2", () => {
+		addListener("changeParticipants", () => {
             showParticipants(props.channelId);
 		});
 	});

--- a/Front-End/src/components/utils/SelectDialog.tsx
+++ b/Front-End/src/components/utils/SelectDialog.tsx
@@ -78,7 +78,7 @@ React.useEffect(() => {
 }, [props.channelId, props.type])
 
 React.useEffect(() => {
-	addListener("joinedChannelR3", () => {
+	addListener("changeParticipants", () => {
 		fetchUsers();
 	});
 });


### PR DESCRIPTION
Les listes admin se mttaient à jour des arrivants sur les PUBLIQUES. Maintenant elle se met à jout sur les sortants ET sur les arrivants et les sortants des PRIV ET PROT channels.
+
FIX de j'envoie une message sur deleted ROOM